### PR TITLE
refactor: extract DSP operations and add pspectrum implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
 TimeseriesUtilitiesAxisKeysExt = "AxisKeys"
-TimeseriesUtilitiesDSPExt = ["DimensionalData", "DSP", "Unitful"]
+TimeseriesUtilitiesDSPExt = "DSP"
 TimeseriesUtilitiesDimensionalDataExt = "DimensionalData"
 TimeseriesUtilitiesSpaceDataModelExt = "SpaceDataModel"
 TimeseriesUtilitiesUnitfulExt = "Unitful"

--- a/ext/TimeseriesUtilitiesAxisKeysExt.jl
+++ b/ext/TimeseriesUtilitiesAxisKeysExt.jl
@@ -6,6 +6,7 @@ import TimeseriesUtilities:
     dimnum,
     dims,
     rebuild_axis,
+    rebuild_axes,
     times,
     unwrap
 using AxisKeys: KeyedArray
@@ -21,6 +22,10 @@ function rebuild_axis(x::KeyedArray, data, dim, keys)
         i == dim ? keys : axiskeys(x, i)
     end
     return KeyedArray(data; NamedTuple{names}(newkeys)...)
+end
+
+function rebuild_axes(::KeyedArray, data, dims, keys)
+    return KeyedArray(data; NamedTuple{dims}(keys)...)
 end
 
 end

--- a/ext/TimeseriesUtilitiesDSPExt.jl
+++ b/ext/TimeseriesUtilitiesDSPExt.jl
@@ -1,19 +1,68 @@
 module TimeseriesUtilitiesDSPExt
 
 using DSP
+using DSP: Butterworth, Bandpass, digitalfilter, filtfilt
 import TimeseriesUtilities
-using TimeseriesUtilities: samplingrate
-using DimensionalData: AbstractDimArray, rebuild
-using Unitful
+using TimeseriesUtilities: TimeOffsets
 
-function TimeseriesUtilities.tfilter(da::AbstractDimArray, Wn1, Wn2 = nothing; designmethod = nothing)
-    designmethod = @something(designmethod, Butterworth(2))
-    fs = samplingrate(da)
+function _sampling_frequency(ts)
+    dt = TimeseriesUtilities.resolution(ts)
+    return inv(TimeseriesUtilities._seconds(dt))
+end
+
+function TimeseriesUtilities.tfilter(
+        A::AbstractArray,
+        ts::AbstractVector,
+        Wn1::Real,
+        Wn2 = nothing;
+        designmethod = Butterworth(2),
+        dim = ndims(A),
+    )
+    length(ts) == size(A, dim) || throw(DimensionMismatch("length(times) must match size(data, dim)"))
+    fs = _sampling_frequency(ts)
     Wn2 = @something(Wn2, 0.999 * fs / 2)
-    Wn1, Wn2, fs = (Wn1, Wn2, fs) ./ 1u"Hz" .|> NoUnits
     f = digitalfilter(Bandpass(Wn1, Wn2), designmethod; fs)
-    res = filtfilt(f, ustrip.(parent(da)))
-    return rebuild(da; data = res * (da |> eltype |> unit))
+    return mapslices(slice -> filtfilt(f, slice), A; dims = dim)
+end
+
+"""
+    pspectrum(data, times; nfft=256, noverlap=div(nfft, 2), window=DSP.hamming)
+
+Compute a short-time Fourier power spectrum from vector data and coordinates.
+"""
+function TimeseriesUtilities.pspectrum(
+        x::AbstractVector,
+        ts::AbstractVector;
+        dim = nothing,
+        nfft = 256,
+        noverlap = div(nfft, 2),
+        window = DSP.hamming,
+    )
+    dim in (nothing, 1) || throw(ArgumentError("dimension $dim out of range for vector input"))
+    length(x) == length(ts) || throw(DimensionMismatch("data and times must have the same length"))
+    spec = DSP.spectrogram(x, nfft, noverlap; fs = _sampling_frequency(ts), window)
+    return (power = spec.power, time = TimeOffsets(spec.time, first(ts)), freq = spec.freq)
+end
+
+function TimeseriesUtilities.pspectrum(
+        A::AbstractArray,
+        ts::AbstractVector;
+        dim = ndims(A),
+        nfft = 256,
+        noverlap = div(nfft, 2),
+        window = DSP.hamming,
+    )
+    length(ts) == size(A, dim) || throw(DimensionMismatch("length(times) must match size(data, dim)"))
+    ndims(A) == 1 && return TimeseriesUtilities.pspectrum(vec(A), ts; nfft, noverlap, window)
+
+    odims = Tuple(i for i in 1:ndims(A) if i != dim)
+    specs = map(eachslice(A; dims = odims)) do slice
+        TimeseriesUtilities.pspectrum(vec(slice), ts; nfft, noverlap, window)
+    end
+
+    first_spec = first(specs)
+    power = stack(spec.power for spec in specs)
+    return (power = power, time = first_spec.time, freq = first_spec.freq)
 end
 
 end

--- a/ext/TimeseriesUtilitiesDimensionalDataExt.jl
+++ b/ext/TimeseriesUtilitiesDimensionalDataExt.jl
@@ -22,6 +22,7 @@ import TimeseriesUtilities:
     groupby_dynamic,
     norm_combine,
     rebuild_axis,
+    rebuild_axes,
     smooth,
     sorted_axis,
     times,
@@ -35,6 +36,7 @@ unwrap(x::AbstractDimArray) = parent(x)
 unwrap(x::Dimension) = parent(lookup(x))
 dimnum(x::AbstractDimLike, dim) = DD.dimnum(x, @something dim TimeDim)
 axiskeys(x::AbstractDimLike, dim) = unwrap(DD.dims(x, dim))
+dims(x::AbstractDimLike, dim) = DD.dims(x, dim)
 times(x::AbstractDimLike, dim = nothing) = axiskeys(x, dimnum(x, dim))
 
 for f in (:dims,)
@@ -71,6 +73,14 @@ end
     newdim = DD.rebuild(olddim; val = DD.rebuild(lookup(olddim); data = keys))
     newdims = Base.setindex(olddims, newdim, dim)
     return rebuild(x, data, newdims)
+end
+
+_dim_from_keys(dim::Symbol, keys) = DD.Dim{dim}(keys)
+_dim_from_keys(dim::Dimension, keys) = rebuild(dim, keys)
+
+function rebuild_axes(x::AbstractDimArray, data, newdims, keys)
+    dims = map(_dim_from_keys, newdims, keys)
+    return rebuild(x, data, DD.format(dims, data))
 end
 
 function smooth(da::AbstractDimArray, window; dim = nothing, kwargs...)

--- a/src/TimeseriesUtilities.jl
+++ b/src/TimeseriesUtilities.jl
@@ -39,7 +39,7 @@ From data cleaning to arithmetic operations (e.g. linear algebra) to common time
 
 ## Time-Frequency Domain Operations
 
-- [`tfilter`](@ref)
+- [`tfilter`](@ref), [`pspectrum`](@ref)
 """
 module TimeseriesUtilities
 
@@ -70,7 +70,7 @@ export tsum, tmean, tmedian, tstd, tsem, tvar
 export tderiv, tsubtract
 
 # Data cleaning
-export smooth, tfilter
+export smooth
 export dropna
 export find_outliers, replace_outliers!, replace_outliers
 
@@ -89,21 +89,7 @@ include("lazyoperations.jl")
 include("interp.jl")
 include("outliers.jl")
 include("utils.jl")
-
-"""
-    tfilter(data, Wn1, Wn2=nothing; designmethod=nothing)
-
-Bandpass filter `data` between `Wn1` and `Wn2`. The upper cutoff defaults to the Nyquist frequency.
-
-References
-- https://docs.juliadsp.org/stable/filters/
-- https://www.mathworks.com/help/signal/ref/filtfilt.html
-- https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.filtfilt.html
-
-Issues
-- DSP.jl and Unitful.jl: https://github.com/JuliaDSP/DSP.jl/issues/431
-"""
-function tfilter end
+include("timefrequency.jl"); export tfilter, pspectrum
 
 include("compat.jl")
 

--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -8,7 +8,6 @@ function tsubtract(x, op = nanmedian; dim = nothing)
     return x .- op(parent(x); dims)
 end
 
-_seconds(dt::Period) = dt / Second(1)
 _deriv_tfunc(T1::Type, T2::Type) = identity
 _deriv_tfunc(::Type{T1}, ::Type{T2}) where {T1 <: Real, T2 <: Dates.TimeType} = _seconds
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -9,12 +9,13 @@ Get the ordinal of the dimension `dim` in `x`.
 """
 dimnum(x, dim) = @something dim ndims(x)
 
-function axiskeys end
+axiskeys(x, _) = throw(MethodError(axiskeys, (x,)))
 
-function dims end
+dims(x, _) = throw(MethodError(dims, (x,)))
 
 rebuild_axis(x, data, dim, keys) = data
 rebuild_axis(x, dim, keys) = rebuild_axis(x, parent(x), dim, keys)
+rebuild_axes(x, data, dims, keys) = data
 
 sorted_axis(sorted, dim; rev = false) = sorted
 
@@ -26,6 +27,9 @@ Get time coordinate of `x`.
 times(x) = x
 
 function samplingrate end
+
+_seconds(dt::Period) = dt / Second(1)
+_seconds(dt) = dt
 
 """
     unwrap(x)

--- a/src/timefrequency.jl
+++ b/src/timefrequency.jl
@@ -1,0 +1,42 @@
+"""
+    tfilter(A, times, Wn1, Wn2=nothing; dim=ndims(A), designmethod=nothing)
+    tfilter(A, Wn1, Wn2=nothing; dim=nothing, designmethod=nothing)
+
+Bandpass filter `A` between `Wn1` and `Wn2`. The upper cutoff defaults to
+the Nyquist frequency.
+
+References
+- https://docs.juliadsp.org/stable/filters/
+- https://www.mathworks.com/help/signal/ref/filtfilt.html
+- https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.filtfilt.html
+"""
+function tfilter end
+
+function tfilter(A, Wn1, Wn2 = nothing; dim = nothing, kwargs...)
+    d = dimnum(A, dim)
+    ts = axiskeys(A, d)
+    data = tfilter(unwrap(A), ts, Wn1, Wn2; dim = d, kwargs...)
+    return rebuild_axis(A, data, d, ts)
+end
+
+"""
+    pspectrum(A, times; dim=ndims(A), nfft=256, noverlap=div(nfft, 2), window=DSP.hamming)
+    pspectrum(A; dim=nothing, freqdim=:frequency, kwargs...)
+
+Compute a time-frequency power spectrum with `DSP.spectrogram`.
+
+For containers that implement the common axis API, `times` are inferred from
+the selected axis and the result is rebuilt with frequency and spectrogram time
+axes followed by the remaining axes.
+"""
+function pspectrum end
+
+function pspectrum(A; dim = nothing, freqdim = :frequency, kwargs...)
+    d = dimnum(A, dim)
+    ts = axiskeys(A, d)
+    spec = pspectrum(unwrap(A), ts; dim = d, kwargs...)
+    odims = Tuple(i for i in 1:ndims(A) if i != d)
+    newdims = (freqdim, dims(A, d), ntuple(i -> dims(A, odims[i]), length(odims))...)
+    keys = (spec.freq, spec.time, ntuple(i -> axiskeys(A, odims[i]), length(odims))...)
+    return rebuild_axes(A, spec.power, newdims, keys)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,21 @@
 /ₜ(x, n) = x / n
 /ₜ(x::P, n) where {P <: Dates.AbstractTime} = P(cld(Dates.value(x), n))
 
+# Handle numeric offsets for datetime-like types (default to Unix epoch)
+struct TimeOffsets{T, A <: AbstractArray} <: AbstractVector{T}
+    offsets::A
+    t0::T
+end
+
+TimeOffsets(offsets) = TimeOffsets(offsets, Dates.unix2datetime(0))
+
+Base.size(to::TimeOffsets) = size(to.offsets)
+function Base.getindex(to::TimeOffsets, i::Int)
+    _add(t0, dt) = t0 + dt
+    _add(t0::Dates.AbstractTime, dt::Number) = t0 + Nanosecond(round(Int, 1.0e9 * dt))
+    return _add(to.t0, to.offsets[i])
+end
+
 """
     tsplit(t0, t1, n::Int)
     tsplit(t0, t1, dt)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,21 @@ using TestItems, TestItemRunner
     using Aqua
     Aqua.test_all(TimeseriesUtilities)
 end
+
+@testitem "api" begin
+    using TimeseriesUtilities: axiskeys, dims, rebuild_axes
+    @test_throws MethodError axiskeys([1, 2, 3], 1)
+    @test_throws MethodError dims([1, 2, 3], 1)
+    @test rebuild_axes([1, 2, 3], 2:4, 1, 1:3) == 2:4
+end
+
+@testitem "TimeOffsets" begin
+    using Dates
+    using TimeseriesUtilities: TimeOffsets
+    to = TimeOffsets(Day.(0:3), DateTime(2020, 1, 1))
+    @test length(to) == 4
+    @test to[[1, 4]] == DateTime.(2020, 1, [1, 4])
+    to = TimeOffsets(1:10)
+    @test length(to) == 10
+    @test to[[1, 10]] == DateTime.(1970, 1, 1) .+ Second.([1, 10])
+end

--- a/test/test_DSP.jl
+++ b/test/test_DSP.jl
@@ -1,19 +1,112 @@
-@testitem "tfilter" begin
-    using DimensionalData
-    using Unitful
+@testitem "tfilter raw arrays" begin
     using DSP
 
-    fs = 100u"Hz"
+    fs = 100
     n = 512
-    t = Ti((0:(n - 1)) ./ ustrip(fs) .* u"s")
-    # 5 Hz signal well inside a 1–20 Hz bandpass
-    signal = sin.(2π * 5 .* (0:(n - 1)) ./ ustrip(fs))
-    da = DimArray(signal, (t,))
-
-    result = tfilter(da, 1u"Hz", 20u"Hz")
-    @test size(result) == size(da)
-    @test dims(result, Ti) == dims(da, Ti)
-    # passband signal should be mostly preserved (within 5% after transient edges)
+    t = (0:(n - 1)) ./ fs
+    signal = sin.(2π * 5 .* t)
     interior = (n ÷ 10):(9n ÷ 10)
+
+    result = tfilter(signal, t, 1, 20)
+    @test size(result) == size(signal)
     @test maximum(abs.(result[interior] .- signal[interior])) < 0.05
+
+    multi = permutedims(hcat(signal, cos.(2π * 5 .* t)))
+    multi_result = tfilter(multi, t, 1, 20; dim = 2)
+    @test size(multi_result) == size(multi)
+    @test maximum(abs.(multi_result[1, interior] .- signal[interior])) < 0.05
+
+    @test_throws DimensionMismatch tfilter(multi, t[1:(end - 1)], 1, 20; dim = 2)
+end
+
+@testitem "tfilter axis containers" begin
+    using AxisKeys
+    using DimensionalData
+    using DSP
+
+    fs = 100
+    n = 512
+    t = (0:(n - 1)) ./ fs
+    signal = sin.(2π * 5 .* t)
+    interior = (n ÷ 10):(9n ÷ 10)
+
+    da = DimArray(signal, (Ti(t),))
+    result = tfilter(da, 1, 20)
+
+    keyed = KeyedArray(signal; time = t)
+    keyed_result = tfilter(keyed, 1, 20)
+
+    @test size(result) == size(keyed_result) == size(signal)
+    @test dims(result, Ti) == dims(da, Ti)
+    @test axiskeys(keyed_result, 1) == axiskeys(keyed, 1)
+    @test maximum(abs.(result[interior] .- signal[interior])) < 0.05
+
+    multi = DimArray(permutedims(hcat(signal, cos.(2π * 5 .* t))), (Dim{:comp}([:x, :y]), Ti(t)))
+    multi_result = tfilter(multi, 1, 20; dim = Ti)
+    @test size(multi_result) == size(multi)
+    @test dims(multi_result, Ti) == dims(multi, Ti)
+    @test dims(multi_result, Dim{:comp}) == dims(multi, Dim{:comp})
+end
+
+@testitem "pspectrum raw arrays" begin
+    using Dates
+    using DSP
+
+    ts = DateTime(2020):Second(1):(DateTime(2020) + Second(99))
+    signal = sin.(1:100)
+    raw = pspectrum(signal, ts; nfft = 16)
+
+    @test size(raw.power) == (9, 11)
+    @test raw.time[1] == DateTime("2020-01-01T00:00:08")
+    @test raw.freq[1] == 0.0
+
+    ts_time = Time(0):Nanosecond(500_000_000):(Time(0) + Nanosecond(500_000_000 * 99))
+    raw_time = pspectrum(signal, ts_time; nfft = 16)
+    @test raw_time.time[1] == Time(0) + Second(4)
+
+    multi = permutedims(hcat(signal, cos.(1:100)))
+    multi_spec = pspectrum(multi, ts; dim = 2, nfft = 16)
+    @test size(multi_spec.power) == (9, 11, 2)
+    @test multi_spec.time == raw.time
+    @test multi_spec.freq == raw.freq
+
+    @test_throws DimensionMismatch pspectrum(multi, ts[1:(end - 1)]; dim = 2, nfft = 16)
+end
+
+@testitem "pspectrum axis containers" begin
+    using AxisKeys
+    using Dates
+    using DimensionalData
+    using DSP
+
+    ts = DateTime(2020):Second(1):(DateTime(2020) + Second(99))
+    da = DimArray(sin.(1:100), (Ti(ts),))
+
+    y = pspectrum(da; nfft = 16)
+    raw = pspectrum(parent(da), ts; nfft = 16)
+    y_default = pspectrum(da)
+    keyed = KeyedArray(sin.(1:100); time = ts)
+    keyed_spec = pspectrum(keyed; nfft = 16)
+
+    @test size(y) == size(keyed_spec) == (9, 11)
+    @test parent(y) == parent(keyed_spec) == raw.power
+    @test dims(y, Dim{:frequency}).val == axiskeys(keyed_spec, :frequency) == raw.freq
+    @test dims(y, Ti).val == axiskeys(keyed_spec, :time) == raw.time
+    @test size(y_default, 1) == 129
+    @test dims(y, Ti)[1] == DateTime("2020-01-01T00:00:08")
+    @test dims(y, Dim{:frequency})[1] == 0.0
+
+    multi = DimArray(hcat(sin.(1:100), cos.(1:100)), (Ti(ts), Dim{:comp}([:x, :y])))
+    multi_spec = pspectrum(multi; nfft = 16)
+    multi_t2 = DimArray(permutedims(parent(multi)), (Dim{:comp}([:x, :y]), Ti(ts)))
+    multi_t2_spec = pspectrum(multi_t2; dim = Ti, nfft = 16)
+    keyed_multi = KeyedArray(permutedims(parent(multi)); comp = [:x, :y], time = ts)
+    keyed_multi_spec = pspectrum(keyed_multi; dim = :time, nfft = 16)
+
+    @test size(multi_spec) == size(multi_t2_spec) == size(keyed_multi_spec) == (9, 11, 2)
+    @test parent(multi_spec) == parent(keyed_multi_spec)
+    @test dims(multi_spec, Dim{:frequency}).val == axiskeys(keyed_multi_spec, :frequency) == raw.freq
+    @test dims(multi_spec, Ti).val == axiskeys(keyed_multi_spec, :time) == raw.time
+    @test dims(multi_spec, Dim{:comp}).val == dims(multi_t2_spec, Dim{:comp}).val == axiskeys(keyed_multi_spec, :comp) == [:x, :y]
+    @test AxisKeys.dimnames(keyed_multi_spec) == (:frequency, :time, :comp)
 end


### PR DESCRIPTION
  - Remove DimensionalData and Unitful dependencies from DSPExt 
  - Implement tfilter and pspectrum for raw arrays with time coordinates - Add rebuild_axes to AxisKeys and DimensionalData extensions